### PR TITLE
Cf 896 init script

### DIFF
--- a/flume-package/build.gradle
+++ b/flume-package/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-
 buildscript {
     repositories {
         mavenLocal()

--- a/flume-package/build.gradle
+++ b/flume-package/build.gradle
@@ -22,7 +22,6 @@ apply plugin: 'de.undercouch.download'
 
 group = 'org.openrepose'
 
-
 publishing {
     publications {
         mavenRpm(MavenPublication) {
@@ -101,7 +100,7 @@ buildRpm {
         include 'flume-ng'
         user 'root'
         permissionGroup 'root'
-        fileMode 0744
+        fileMode 0644
     }
 
     from( 'src/main/resources/init.d/rpm' ) {

--- a/flume-package/build.gradle
+++ b/flume-package/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 buildscript {
     repositories {
         mavenLocal()
@@ -21,6 +23,7 @@ apply plugin: 'org.hidetake.ssh'
 apply plugin: 'de.undercouch.download'
 
 group = 'org.openrepose'
+
 
 publishing {
     publications {
@@ -57,7 +60,21 @@ task downloadFlume(type: Download) {
 task unpackFlume(dependsOn: downloadFlume, type: Copy) {
     from tarTree(resources.gzip(flumeArchive))
     into buildDir
+    exclude '**/log4j.properties'
 }
+
+task filterLog4j( dependsOn: unpackFlume, type: Copy ) {
+    from tarTree(resources.gzip(flumeArchive))
+    into buildDir
+    include '**/log4j.properties'
+
+    // to support running flume as a service, write logs to absolute path, standard location
+    filter { line -> line.contains( 'flume.log.dir=./logs' ) ? 'flume.log.dir=/var/log/flume' : line }
+}
+
+def app_user = 'flume'
+def app_group = 'flume'
+def log_path = '/var/log/flume'
 
 ospackage {
     packageName 'flume-repose'
@@ -67,15 +84,38 @@ ospackage {
 
     preInstall file("$parent.projectDir/preInstall.sh")
 
-    user 'flume'
-    permissionGroup 'flume'
+    user app_user
+    permissionGroup app_group
     os 'LINUX'
 
     from flumeDir
     into '/opt/flume'
+
+    // looks like its not straightforward to create a directory with no files.  This works, though.
+    // https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/14
+    postInstall 'mkdir -p ' + log_path + '; chown -R ' + app_user + ':' + app_group + ' ' + log_path
 }
 
-buildRpm.dependsOn unpackFlume
+buildRpm {
+
+    from( 'src/main/resources/sysconfig' ) {
+        into '/etc/sysconfig'
+        include 'flume-ng'
+        user 'root'
+        permissionGroup 'root'
+        fileMode 0744
+    }
+
+    from( 'src/main/resources/init.d/rpm' ) {
+        into '/etc/init.d'
+        include 'flume-ng'
+        user 'root'
+        permissionGroup 'root'
+        fileMode 0755
+    }
+}
+
+buildRpm.dependsOn filterLog4j
 buildDeb.dependsOn unpackFlume
 
 apply from: '../remotesConfig.gradle'

--- a/flume-package/src/main/resources/init.d/rpm/flume-ng
+++ b/flume-package/src/main/resources/init.d/rpm/flume-ng
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Startup script for Flume-Repose
+#
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+# Set sensible defaults
+LOG_PATH=/var/log/flume
+# NOTE:  flume references java from JAVA_HOME, so this is configured differently than the repose
+# init script.
+export JAVA_HOME=/usr/lib/jvm/jre-1.7.0-openjdk.x86_64
+CONFIG_DIRECTORY=/opt/flume/conf
+COMMAND=/opt/flume/bin/flume-ng
+USER=flume
+NAME=flume-ng
+DAEMON_HOME=/opt/flume
+PID_FILE=/var/run/${NAME}.pid
+START_ARGS="-c $DAEMON_HOME -p $PID_FILE -u $USER -o $LOG_PATH/stdout.log -e $LOG_PATH/stderr.log -l /var/lock/subsys/$NAME"
+RUN_ARGS="agent -n repose-agent -c $CONFIG_DIRECTORY -f $CONFIG_DIRECTORY/cf-flume-conf.properties"
+# NOTE:  flume declares its JVM arguments in /opt/flume/conf/flume-env.sh, not here
+daemonize=/usr/sbin/daemonize
+
+# Can override the defaults in /etc/sysconfig
+. /etc/sysconfig/flume-ng
+
+if [ ! -d $DAEMON_HOME ]; then
+  echo "Unable to find $NAME's directory: $DEAMON_HOME."
+  exit 1
+fi
+
+if [ ! -d $CONFIG_DIRECTORY ]; then
+  echo "Unable to find $CONFIG_DIRECTORY."
+  exit 1
+fi
+
+if [ ! -d $LOG_PATH ]; then
+  echo "Unable to log to $LOG_PATH."
+  exit 1
+fi
+
+start()
+{
+  echo -n "Starting $NAME: "
+  daemon $daemonize $START_ARGS $COMMAND $RUN_ARGS 
+  echo
+}
+
+stop()
+{
+  echo -n "Stopping $NAME: "
+
+  killproc -p $PID_FILE -d 3 $NAME && rm -f /var/lock/subsys/$NAME
+  echo
+}
+
+
+case "$1" in
+  start)
+    start
+    ;;
+
+  stop)
+    stop
+    ;;
+
+  restart)
+    stop
+    start
+    ;;
+
+  status)
+    status -p $PID_FILE $NAME
+    ;;
+
+  *)
+    echo "Usage: /etc/init.d/$NAME {start|stop|restart|status}"
+    exit 1
+esac

--- a/flume-package/src/main/resources/sysconfig/flume-ng
+++ b/flume-package/src/main/resources/sysconfig/flume-ng
@@ -1,15 +1,1 @@
-# Set sensible defaults
-LOG_PATH=/var/log/flume
-# NOTE:  flume references java from JAVA_HOME, so this is configured differently than the repose
-# init script.
-export JAVA_HOME=/usr/lib/jvm/jre-1.7.0-openjdk.x86_64
-CONFIG_DIRECTORY=/opt/flume/conf
-COMMAND=/opt/flume/bin/flume-ng
-USER=flume
-NAME=flume-ng
-DAEMON_HOME=/opt/flume
-PID_FILE=/var/run/${NAME}.pid
-START_ARGS="-c $DAEMON_HOME -p $PID_FILE -u $USER -o $LOG_PATH/stdout.log -e $LOG_PATH/stderr.log -l /var/lock/subsys/$NAME"
-RUN_ARGS="agent -n repose-agent -c $CONFIG_DIRECTORY -f $CONFIG_DIRECTORY/cf-flume-conf.properties"
-# NOTE:  flume declares its JVM arguments in /opt/flume/conf/flume-env.sh, not here
-daemonize=/usr/sbin/daemonize
+#RUN_ARGS="agent -n repose-agent -c $CONFIG_DIRECTORY -f $CONFIG_DIRECTORY/cf-flume-conf.properties"

--- a/flume-package/src/main/resources/sysconfig/flume-ng
+++ b/flume-package/src/main/resources/sysconfig/flume-ng
@@ -1,0 +1,15 @@
+# Set sensible defaults
+LOG_PATH=/var/log/flume
+# NOTE:  flume references java from JAVA_HOME, so this is configured differently than the repose
+# init script.
+export JAVA_HOME=/usr/lib/jvm/jre-1.7.0-openjdk.x86_64
+CONFIG_DIRECTORY=/opt/flume/conf
+COMMAND=/opt/flume/bin/flume-ng
+USER=flume
+NAME=flume-ng
+DAEMON_HOME=/opt/flume
+PID_FILE=/var/run/${NAME}.pid
+START_ARGS="-c $DAEMON_HOME -p $PID_FILE -u $USER -o $LOG_PATH/stdout.log -e $LOG_PATH/stderr.log -l /var/lock/subsys/$NAME"
+RUN_ARGS="agent -n repose-agent -c $CONFIG_DIRECTORY -f $CONFIG_DIRECTORY/cf-flume-conf.properties"
+# NOTE:  flume declares its JVM arguments in /opt/flume/conf/flume-env.sh, not here
+daemonize=/usr/sbin/daemonize


### PR DESCRIPTION
Adding the following to repose-flume installation:
- Adding /etc/init.d/flume-ng & /etc/sysconfig/flume-ng init scripts for rpm install
- Modifying log4j.properties to write logs to /var/log/flume
- Creating /var/log/flume directory