### PR TITLE
readding export JAVA_HOME to init.d files

### DIFF
--- a/flume-package/src/main/resources/init.d/deb/flume-ng
+++ b/flume-package/src/main/resources/init.d/deb/flume-ng
@@ -55,6 +55,8 @@ if [ ! -d $JAVA_HOME ]; then
     exit 1
 fi
 
+export JAVA_HOME
+
 start()
 {
   start-stop-daemon $START_ARGS --chuid $USER:$USER --exec $COMMAND -- $RUN_ARGS

--- a/flume-package/src/main/resources/init.d/rpm/flume-ng
+++ b/flume-package/src/main/resources/init.d/rpm/flume-ng
@@ -48,6 +48,8 @@ if [ ! -d $JAVA_HOME ]; then
     exit 1
 fi
 
+export JAVA_HOME
+
 start()
 {
   echo -n "Starting $NAME: "


### PR DESCRIPTION
When the export JAVA_HOME line was removed, it breaks flume-ng startup.  I readded it after the JAVA_HOME variable existence check.